### PR TITLE
Fixing uninitialized logger

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -28,13 +28,13 @@ require 'benchmark'
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'tootsie'
 
-config_path = File.expand_path("../tootsie.conf", __FILE__)
-if File.exist?(config_path)
-  Tootsie::Configuration.instance.load_from_file(config_path)
-end
-
 unless defined?(LOGGER)
   $stdout.sync = true
   LOGGER = Logger.new($stdout)
   LOGGER.level = $DEBUG ? Logger::DEBUG : Logger::INFO
+end
+
+config_path = File.expand_path("../tootsie.conf", __FILE__)
+if File.exist?(config_path)
+  Tootsie::Configuration.instance.load_from_file(config_path)
 end

--- a/lib/tootsie/configuration.rb
+++ b/lib/tootsie/configuration.rb
@@ -8,7 +8,7 @@ module Tootsie
       @ffmpeg_thread_count = 1
       @queue_options = {}
       @river = Pebbles::River::River.new
-      @logger = LOGGER if defined?(logger)
+      @logger = LOGGER if defined?(LOGGER)
       @logger ||= Logger.new($stdout)
       @use_legacy_completion_event = true
       @failure_queue_ttl = nil


### PR DESCRIPTION
This PR addresses tootsie a crash during initialization with a `tootsie.conf` file without firstly initializing a custom logger.

Steps to reproduce:
1. Create and fill out `config/tootsie.conf`. Do not add a custom logger.
2. Launch tootsie.

Expected: Service launched or errors as needed.
Observed: Crash with ```/srv/tootsie/lib/tootsie/configuration.rb:11:in `initialize': uninitialized constant Tootsie::Configuration::LOGGER (NameError)```